### PR TITLE
Add support for verify-clients

### DIFF
--- a/docs/security-reference.md
+++ b/docs/security-reference.md
@@ -17,16 +17,17 @@ it simply provides a managed way to configure the derper service, by providing s
 On first run, derper generates a secret key and writes it to file at `$SNAP_COMMON/derper.key`. This file is only readable or writeable by the root user.
 Note that derper refers to this file as the config file.
 
-WARNING: Derper acts as an open relay by default,
-and the snap does not currently support the `--verify-clients` mode that can restrict traffic to your tailnet.
-Please see https://github.com/canonical/derper-snap/pull/4 for more information and the work in progress.
+WARNING: Derper acts as an open relay by default.
+Please see the "Verify client connections" section in the security hardening guidance below
+for instructions for restricting access.
 
 ## Security hardening guidance
 
 ### Listen address and protocol
 
 With the default snap config of `a` (the server listen address),
-Derper will listen on port 443, and request a certificate from Letsencrypt to use HTTPS.
+Derper will bind to all interfaces, listening on port 443, and request a certificate from Letsencrypt to use HTTPS.
+
 If the listen port is changed to something other than 443,
 Derper will not request a certificate, and will listen on HTTP instead.
 It's recommended to leave the port as 443 to ensure HTTPS will be used.
@@ -38,10 +39,21 @@ For example:
 sudo snap set derper a=10.0.0.3:443
 ```
 
-### Open relay warning
+### Verify client connections
 
 By default, Derper runs as an open relay.
-Derper does make it possible to restrict access to traffic on your tailnet only,
-by using its `--verify-clients` mode.
-However, this is not currently supported by the snap.
-Please see https://github.com/canonical/derper-snap/pull/4 for more information and the work in progress.
+Derper does provide a `-verify-clients` mode to restrict access to traffic on your tailnet only.
+To turn on this mode in the snap:
+
+1. Ensure the Tailscale snap is also installed on the same machine.
+2. Ensure the `socket` interface on the Tailscale snap is connected to the `tailscale-socket` interface on the Derper snap.
+3. set `verify-clients=true` on the Derper snap config.
+
+For example:
+
+```
+sudo snap install derper
+sudo snap install tailscale
+sudo snap connect derper:tailscale-socket tailscale:socket
+sudo snap set derper verify-clients=true
+```

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -23,6 +23,4 @@ validate_bool() {
     fi
 }
 
-# TODO: for verify-clients, also verify that the connection to tailscale is present if setting the value to true.
-# Otherwise, fail and recommend the user run `sudo snap connect derper:tailscale-socket tailscale:socket`
 validate_bool verify-clients

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -6,6 +6,7 @@
 [ -z "$(snapctl get a)" ] && snapctl set a=
 [ -z "$(snapctl get hostname)" ] && snapctl set hostname=
 [ -z "$(snapctl get stun-port)" ] && snapctl set stun-port=
+[ -z "$(snapctl get verify-clients)" ] && snapctl set verify-clients=false
 
 
 # For validating boolean options that must be "true" or "false"
@@ -21,3 +22,7 @@ validate_bool() {
         exit 1
     fi
 }
+
+# TODO: for verify-clients, also verify that the connection to tailscale is present if setting the value to true.
+# Otherwise, fail and recommend the user run `sudo snap connect derper:tailscale-socket tailscale:socket`
+validate_bool verify-clients

--- a/snap/local/derper-service
+++ b/snap/local/derper-service
@@ -21,5 +21,6 @@ add_option hostname
 add_option stun-port
 add_flag verify-clients
 
-# Hardcoding config file path, as it defaults to /var/lib/derper/derper.key otherwise.
-exec "${SNAP}/bin/derper" -c "$SNAP_COMMON/derper.key" "${args[@]}"
+# Hardcode the config file path, as it defaults to /var/lib/derper/derper.key otherwise.
+# Also hardcode the tailscaled socket path; this path is present if the tailscale-socket plug is connected.
+exec "${SNAP}/bin/derper" "-c=$SNAP_COMMON/derper.key" "-socket=$SNAP_DATA/tailscale-socket/tailscaled.sock" "${args[@]}"

--- a/snap/local/derper-service
+++ b/snap/local/derper-service
@@ -19,6 +19,7 @@ add_flag() {
 add_option a
 add_option hostname
 add_option stun-port
+add_flag verify-clients
 
 # Hardcoding config file path, as it defaults to /var/lib/derper/derper.key otherwise.
 exec "${SNAP}/bin/derper" -c "$SNAP_COMMON/derper.key" "${args[@]}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,7 @@ description: |
   * `hostname`: LetsEncrypt host name, if addr's (`a`) port is :443. (default if unset: "derp.tailscale.com")
   * `a`: server HTTP/HTTPS listen address, in form ":port", "ip:port", or for IPv6 "[ip]:port". If the IP is omitted, it defaults to all interfaces. Serves HTTPS if the port is 443 and/or certmode is manual (default certmode is "letsencrypt"), otherwise HTTP. (default if unset: ":443")
   * `stun-port`: The UDP port on which to serve STUN. The listener is bound to the same IP (if any) as specified in the `a` option. (default if unset: "3478")
+  * `verify-clients`: Verify clients to this DERP server through a local tailscaled instance. (default if unset: false)
 
   The config options correspond to the similarly named command line flags for `derper`.
 
@@ -50,6 +51,7 @@ description: |
      Key             Value
      hostname
      a               127.0.0.1:443
+     verify-clients  false
      ...
 
   Derper must be restarted manually for the changed config to take affect:
@@ -66,6 +68,15 @@ description: |
 platforms:
   amd64:
   arm64:
+
+plugs:
+  # to connect to tailscale for verify-clients mode:
+  # $ sudo snap connect derper:tailscale-socket tailscale:socket
+  tailscale-socket:
+    interface: content
+    content: socket-directory
+    # will be available to derper as $SNAP_DATA/tailscale-socket/tailscaled.sock
+    target: $SNAP_DATA/tailscale-socket
 
 apps:
   derper:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,6 +65,7 @@ description: |
      sudo snap install tailscale
      sudo snap connect derper:tailscale-socket tailscale:socket
      sudo snap set derper verify-clients=true
+     sudo snap restart derper
 
   **Security**
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,7 +34,7 @@ description: |
   * `hostname`: LetsEncrypt host name, if addr's (`a`) port is :443. (default if unset: "derp.tailscale.com")
   * `a`: server HTTP/HTTPS listen address, in form ":port", "ip:port", or for IPv6 "[ip]:port". If the IP is omitted, it defaults to all interfaces. Serves HTTPS if the port is 443 and/or certmode is manual (default certmode is "letsencrypt"), otherwise HTTP. (default if unset: ":443")
   * `stun-port`: The UDP port on which to serve STUN. The listener is bound to the same IP (if any) as specified in the `a` option. (default if unset: "3478")
-  * `verify-clients`: Verify clients to this DERP server through a local tailscaled instance. (default if unset: false)
+  * `verify-clients`: Verify clients to this DERP server through a local tailscaled instance. Must be "true" or "false". (default if unset: "false")
 
   The config options correspond to the similarly named command line flags for `derper`.
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,6 +58,14 @@ description: |
 
      sudo snap restart derper
 
+  To run in `verify-clients` mode, the tailscale snap must also be installed,
+  and the two snaps connected over the custom content interface so the control socket is shared:
+
+     sudo snap install derper
+     sudo snap install tailscale
+     sudo snap connect derper:tailscale-socket tailscale:socket
+     sudo snap set derper verify-clients=true
+
   **Security**
 
   See https://github.com/canonical/derper-snap/blob/main/docs/security-reference.md


### PR DESCRIPTION
See also https://github.com/canonical/tailscale-snap/pull/22

See https://github.com/canonical/tailscale-snap/pull/65 for e2e testing instructions.

TODO:
- [x] wait for https://github.com/tailscale/tailscale/pull/15125 to be included in a new tailscale release
- [x] bump tailscale release version in the tailscale snap
- [x] bump tailscale release version in the derper snap
- [x] work on e2e testing, update the e2e test doc ( https://github.com/canonical/tailscale-snap/pull/65 )
- [x] update the docs in this PR where needed
  - [x] Add security hardening guidance to the security doc (depends on https://github.com/canonical/derper-snap/pull/19 ). This should include advice about derper being an open relay by default, and using verify clients appropriately to lock it down.