### PR TITLE
Provide path to config to avoid custom layout

### DIFF
--- a/snap/local/derper-service
+++ b/snap/local/derper-service
@@ -21,4 +21,5 @@ add_option hostname
 add_option stun-port
 add_flag verify-clients
 
-exec "${SNAP}/bin/derper" "${args[@]}"
+# Hardcoding config file path, as it defaults to /var/lib/derper/derper.key otherwise.
+exec "${SNAP}/bin/derper" -c "$SNAP_DATA/derper.key" "${args[@]}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,11 +17,6 @@ platforms:
   arm64:
   armhf:
 
-# TODO: do we need this? is this just for the /var/lib/derper/derper.key config file default?
-layout:
-  /var/lib/derper:
-    bind: $SNAP_DATA/var/lib/derper
-
 apps:
   derper:
     command: bin/derper-service


### PR DESCRIPTION
layout should be avoided if possible because it impacts startup performance. This also makes it simpler,
and we can easily convert it to be configurable if required in the future.