### PR TITLE
Remove another reference to verify-clients

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -6,7 +6,6 @@
 [ -z "$(snapctl get a)" ] && snapctl set a=
 [ -z "$(snapctl get hostname)" ] && snapctl set hostname=
 [ -z "$(snapctl get stun-port)" ] && snapctl set stun-port=
-[ -z "$(snapctl get verify-clients)" ] && snapctl set verify-clients=false
 
 
 validate_bool() {


### PR DESCRIPTION
verify-clients was removed in #6, but this reference was missed.