### PR TITLE
Remove untested architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,8 +14,6 @@ description: |
 
 platforms:
   amd64:
-  arm64:
-  armhf:
 
 apps:
   derper:


### PR DESCRIPTION
Our automation and testing has only covered amd64 so far. We can add other architectures in the future.
But for now, remove them from snapcraft.yaml to avoid confusion.