### PR TITLE
Move derper.key to snap_common

### DIFF
--- a/snap/local/derper-service
+++ b/snap/local/derper-service
@@ -21,4 +21,4 @@ add_option hostname
 add_option stun-port
 
 # Hardcoding config file path, as it defaults to /var/lib/derper/derper.key otherwise.
-exec "${SNAP}/bin/derper" -c "$SNAP_DATA/derper.key" "${args[@]}"
+exec "${SNAP}/bin/derper" -c "$SNAP_COMMON/derper.key" "${args[@]}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,7 +68,7 @@ description: |
   The snap logic does not use any cryptographic functionality directly;
   it simply provides a managed way to configure the derper service, by providing some scripts and interacting with `snapctl`.
 
-  On first run, derper generates a secret key and writes it to file at `$SNAP_DATA/derper.key`. This file is only readable or writeable by the root user.
+  On first run, derper generates a secret key and writes it to file at `$SNAP_COMMON/derper.key`. This file is only readable or writeable by the root user.
   Note that derper refers to this file as the config file.
 
 platforms:


### PR DESCRIPTION
snap_common seems more appropriate than snap_data, because snap_common is for files that don't depend on the revision of the snap. This file should be used across upgrades of derper.