### PR TITLE
Remove reference to unused config var

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -8,6 +8,10 @@
 [ -z "$(snapctl get stun-port)" ] && snapctl set stun-port=
 
 
+# For validating boolean options that must be "true" or "false"
+# (used in the service wrapper to determine which flags to pass).
+# eg: `validate_bool verify-clients`
+# We'll use this when we add the verify-clients option at least.
 validate_bool() {
     key="$1"
     value="$(snapctl get "$key")"
@@ -17,6 +21,3 @@ validate_bool() {
         exit 1
     fi
 }
-
-
-validate_bool verify-clients


### PR DESCRIPTION
`verify-clients` is something we'll add at some point - see #4. But we're blocked on it for now, and can't use it. It looks like this reference was accidentally left here though. It must be removed, otherwise the configure hook will fail, blocking installation of the snap.