### PR TITLE
Update to 1.80.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: derper
 base: core24
-version: 1.78.3
+version: 1.80.2
 license: BSD-3-Clause
 grade: stable
 confinement: strict


### PR DESCRIPTION
This is the latest upstream Tailscale release at time of writing. See:

- https://github.com/tailscale/tailscale/releases/tag/v1.80.2
- https://tailscale.com/changelog#2025-02-13