### PR TITLE
feat: manual certmode with self-signed certs

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 # Register config variables if unset,
 # so users can see available variables by running
@@ -7,6 +7,8 @@
 [ -z "$(snapctl get hostname)" ] && snapctl set hostname=
 [ -z "$(snapctl get stun-port)" ] && snapctl set stun-port=
 [ -z "$(snapctl get verify-clients)" ] && snapctl set verify-clients=false
+[ -z "$(snapctl get certmode)" ] && snapctl set certmode=letsencrypt
+[ -z "$(snapctl get certdir)" ] && snapctl set certdir=
 
 
 # For validating boolean options that must be "true" or "false"
@@ -23,4 +25,33 @@ validate_bool() {
     fi
 }
 
+validate_certmode() {
+    certmode="$(snapctl get certmode)"
+    certdir="$(snapctl get certdir)"
+    hostname="$(snapctl get hostname)"
+
+    case "$certmode" in
+        letsencrypt) ;;
+        manual)
+            [ -n "$certdir" ] ||
+                { echo '"certdir" is required when "certmode" is "manual"' >&2; exit 1; }
+            [ -n "$hostname" ] ||
+                { echo '"hostname" is required when "certmode" is "manual"' >&2; exit 1; }
+            ;;
+        *)
+            echo "\"$certmode\" is not a valid certmode value" >&2
+            exit 1
+            ;;
+    esac
+
+    case "$certdir" in
+        "" ) ;;
+        /*|..|../*|*/..|*"/../"* )
+            echo '"certdir" must be relative to $SNAP_COMMON' >&2
+            exit 1
+            ;;
+    esac
+}
+
 validate_bool verify-clients
+validate_certmode

--- a/snap/local/derper-service
+++ b/snap/local/derper-service
@@ -16,10 +16,18 @@ add_flag() {
     [ "$(snapctl get "$key")" = "true" ] && args+=("-$key")
 }
 
+add_option_path() {
+    key=$1
+    value="$(snapctl get "$key")"
+    [ -n "$value" ] && args+=("-$key=$SNAP_COMMON/$value")
+}
+
 add_option a
 add_option hostname
 add_option stun-port
 add_flag verify-clients
+add_option certmode
+add_option_path certdir
 
 # Hardcode the config file path, as it defaults to /var/lib/derper/derper.key otherwise.
 # Also hardcode the tailscaled socket path; this path is present if the tailscale-socket plug is connected.


### PR DESCRIPTION
# Overview

Adds support for Derper’s upstream manual certificate mode while preserving Let’s Encrypt as the default.

Operators can now provide externally managed certificates, including certificates issued by private CAs or self-signed certificates, when automatic ACME issuance is unavailable or undesirable. The configuration validates the certificate mode and directory before restarting the service.

This also enables the local LXD E2E environment to run Derper with its own test certificates.

## New snap config options:

1. `certmode` - with `manual` and `letsencrypt` as allowed values.
2. `certdir` - a relative path to `$SNAP_COMMON` pointing to a directory with the self-signed certificates.
